### PR TITLE
Update Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
-before_install:
- - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
+xcode_workspace: NZAlertView.xcworkspace
+xcode_scheme: NZAlertView
+xcode_sdk: iphonesimulator

--- a/NZAlertView.xcodeproj/xcshareddata/xcschemes/NZAlertView.xcscheme
+++ b/NZAlertView.xcodeproj/xcshareddata/xcschemes/NZAlertView.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F859C9E91861CF7100CCB7A2"
+               BuildableName = "NZAlertView.app"
+               BlueprintName = "NZAlertView"
+               ReferencedContainer = "container:NZAlertView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F859C9E91861CF7100CCB7A2"
+            BuildableName = "NZAlertView.app"
+            BlueprintName = "NZAlertView"
+            ReferencedContainer = "container:NZAlertView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F859C9E91861CF7100CCB7A2"
+            BuildableName = "NZAlertView.app"
+            BlueprintName = "NZAlertView"
+            ReferencedContainer = "container:NZAlertView.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F859C9E91861CF7100CCB7A2"
+            BuildableName = "NZAlertView.app"
+            BlueprintName = "NZAlertView"
+            ReferencedContainer = "container:NZAlertView.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This class uses UIAlertView default methods and protocols.
   <a href="http://youtu.be/FCZKKN5W9Cc"><img src="http://s10.postimg.org/9n918glqh/NZAlert_View.png" alt="NZAlertView" title="NZAlertView" width="500" height="300"></a>
 </p>
 <br/>
-[![Build Status](https://api.travis-ci.org/NZN/NZAlertView.png)](https://api.travis-ci.org/NZN/NZAlertView.png)
+[![Build Status](https://travis-ci.org/NZN/NZAlertView.svg?branch=master)](https://travis-ci.org/NZN/NZAlertView)
 [![Cocoapods](https://cocoapod-badges.herokuapp.com/v/NZAlertView/badge.png)](http://beta.cocoapods.org/?q=NZAlertView)
 [![Cocoapods](https://cocoapod-badges.herokuapp.com/p/NZAlertView/badge.png)](http://beta.cocoapods.org/?q=NZAlertView)
 [![Analytics](https://ga-beacon.appspot.com/UA-48753665-1/NZN/NZAlertView/README.md)](https://github.com/igrigorik/ga-beacon)
@@ -73,7 +73,7 @@ Alternatively you can directly add source files to your project.
 
 ###Show
 
-```objetive-c
+```objc
 #import "NZAlertView.h"
 ...
 {
@@ -100,7 +100,7 @@ Alternatively you can directly add source files to your project.
 
 * All delegates are optional
 
-```objetive-c
+```objc
 #import "NZAlertViewDelegate.h"
 ...
 
@@ -114,7 +114,7 @@ Alternatively you can directly add source files to your project.
 
 ###Setters and getters
 
-```objetive-c
+```objc
 @property (nonatomic, assign) id delegate;
 @property (nonatomic, assign) NZAlertStyle alertViewStyle;
 @property (nonatomic, copy) NSString *title;


### PR DESCRIPTION
According to the [latest record](https://travis-ci.org/NZN/NZAlertView/builds/38538982), the CI build didn't take place due to the following warning:

> WARNING: Using Objective-C testing without specifying a scheme and either a workspace or a project is deprecated.

This could be resolved by updating `.travis.yml`.
https://travis-ci.org/NZN/NZAlertView/builds/44740775